### PR TITLE
setup-dnt occurred 'Invalid repository name (ex: "registry.domain.tld/myrepos") 

### DIFF
--- a/dnt.sh
+++ b/dnt.sh
@@ -26,7 +26,7 @@ else
 fi
 
 # The versions of Node to test, this assumes that we have a Docker image
-# set up with the name "node_dev-<version>"
+# set up with the name "node_dev/<version>"
 #NODE_VERSIONS=`cat ${__dirname}/node_versions.list`
 
 if [ $# -gt 0 ] ; then
@@ -49,7 +49,7 @@ START_TS=`date +%s`
 test_node() {
   local OUT=/tmp/${OUTPUT_PREFIX}dnt-${NV}.out
   local NV=$1
-  local ID=node_dev-$NV
+  local ID=node_dev/$NV
 
   docker inspect "$ID" &> /dev/null
   if [[ $? -ne 0 ]]; then

--- a/setup-dnt.sh
+++ b/setup-dnt.sh
@@ -66,7 +66,7 @@ setup_container "node_dev" "dev_base" " \
 # For each version of Node, make an image by checking out that branch
 # on the repo, building it and installing it
 for NV in $NODE_VERSIONS; do
-  setup_container "node_dev-$NV" "node_dev" " \
+  setup_container "node_dev/$NV" "node_dev" " \
     cd /usr/src/node && \
     git fetch origin && \
     git checkout $NV && \


### PR DESCRIPTION
I caught an exception like 'Invalid repository name (ex: "registry.domain.tld/myrepos")'

Docker repository name should be able to separate "/", according to the latest docker.

https://github.com/dotcloud/docker/blob/master/registry/registry.go#L103
